### PR TITLE
Fix code block copy JS

### DIFF
--- a/static/js/copy-to-clipboard.js
+++ b/static/js/copy-to-clipboard.js
@@ -34,7 +34,7 @@ document.querySelectorAll("div.highlight pre").forEach((snippet) => {
 // Add copy to clipboard functionality
 const clipboard = new ClipboardJS(".codecopy-btn", {
   target: (trigger) => {
-    return trigger.parentNode;
+    return trigger.parentNode.querySelector("code");
   },
 });
 


### PR DESCRIPTION
This update addresses an issue where an extra line "Copy\n" was being added to the clipboard when using the copy button on code blocks.

Example Before Fix: When copying the command `uv init --app`, the clipboard contained:

```sh
Copy
uv init --app
```

Solution: Narrowed down the scope of copy targets to prevent the addition of the unwanted line.