### PR TITLE
Fix: use correct selector for highlight.js

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -313,8 +313,8 @@
     // Responsive videos with fitVids
     post.fitVids();
 
-    var mdSelector=".highlight pre";
-    var rstSelector=".highlight pre";
+    var mdSelector=".highlight pre code";
+    var rstSelector=".highlight pre code";
     // For ":source-highlighter: highlight.js`" in asciidoc
     var adocSelector="pre.highlight > code[data-lang]"
     {% if article.source_path and article.source_path.lower().endswith(('.md','.markdown')) %}


### PR DESCRIPTION
Previously used `.highlight pre` as selector, which targets `<pre>` elements. This caused `hljs.highlightElement(e)` to fail and broke the copy button.

Updated selector to `.highlight pre code` so that:
* highlight.js targets `<code>` as expected
* copy button works correctly with `<code>` content
* rendered HTML has proper structure (`<pre><code>...</code></pre>`)

No other changes made.

修改這段了理由，是基於：
判斷（猜測）之前 copy 功能壞掉的原因：

1. selector 尋找 code block 時發生錯誤（但是沒有直接跳 error message）
2. Copy 相關 JS 想要觸發時，因為 1. 的錯誤，無法正確運行

[More Info ...](https://hackmd.io/@TTW/rJWyTIZ4xl)
